### PR TITLE
Update Application Gateway SKU in bicep.

### DIFF
--- a/Azure/bicep/README.md
+++ b/Azure/bicep/README.md
@@ -40,8 +40,6 @@ To delete the FME Flow deployment remove the resource group: ```az group delete 
 |`publicIpNewOrExisting`|Determines whether or not a new public ip should be provisioned.|'new'|
 |`publicIpName`|Name of the public ip address|'fmeflow-pip'|
 |`publicIpDns`|DNS of the public ip address for the VM|'fmeflow-{uniqueString}'|
-|`publicIpAllocationMethod`|'Allocation method for the public ip address')|'Dynamic'|
-|`publicIpSku`|Name of the resource group for the public ip address|'Basic'|
 |`applicationGatewayName`|Name of the resource group for the existing virtual network|'fmeflow-appgateway'|
 |`engineRegistrationLoadBalancerName`|Name of the resource group for the existing virtual network'|'fmeflow-engineregistration'|
 |`adminUsername`|Admin username on all VMs.||

--- a/Azure/bicep/main.bicep
+++ b/Azure/bicep/main.bicep
@@ -49,20 +49,6 @@ param publicIpName string = 'fmeflow-pip'
 @description('DNS of the public ip address for the VM')
 param publicIpDns string = 'fmeflow-${uniqueString(resourceGroup().id)}'
 
-@description('Allocation method for the public ip address')
-@allowed([
-  'Dynamic'
-  'Static'
-])
-param publicIpAllocationMethod string = 'Dynamic'
-
-@description('Name of the resource group for the public ip address')
-@allowed([
-  'Basic'
-  'Standard'
-])
-param publicIpSku string = 'Basic'
-
 @description('Name of the resource group for the existing virtual network')
 param applicationGatewayName string = 'fmeflow-appgateway'
 
@@ -88,10 +74,8 @@ module network 'modules/network/network.bicep' = {
   params: {
     addressPrefixes: addressPrefixes
     location: location
-    publicIpAllocationMethod: publicIpAllocationMethod
     publicIpDns: publicIpDns
     publicIpName: publicIpName
-    publicIpSku: publicIpSku
     subnetAGName: subnetAGName
     subnetAGPrefix: subnetAGPrefix
     subnetName: subnetName

--- a/Azure/bicep/modules/lb-services/agw/agw.bicep
+++ b/Azure/bicep/modules/lb-services/agw/agw.bicep
@@ -20,8 +20,8 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
   location: location
   properties: {
     sku: {
-      name: 'Standard_Medium'
-      tier: 'Standard'
+      name: 'Standard_v2'
+      tier: 'Standard_v2'
       capacity: 1
     }
     gatewayIPConfigurations: [
@@ -140,6 +140,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
         name: 'httpRoutingRule'
         properties: {
           ruleType: 'Basic'
+          priority: 1
           httpListener: {
             id: resourceId('Microsoft.Network/applicationGateways/httpListeners', applicationGatewayName, 'httpListener')
           }
@@ -155,6 +156,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
         name: 'websocketRoutingRule'
         properties: {
           ruleType: 'Basic'
+          priority: 2
           httpListener: {
             id: resourceId('Microsoft.Network/applicationGateways/httpListeners', applicationGatewayName, 'websocketListener')
           }

--- a/Azure/bicep/modules/network/network.bicep
+++ b/Azure/bicep/modules/network/network.bicep
@@ -28,20 +28,6 @@ param publicIpName string
 @description('DNS of the public ip address for the VM')
 param publicIpDns string
 
-@description('Allocation method for the public ip address')
-@allowed([
-  'Dynamic'
-  'Static'
-])
-param publicIpAllocationMethod string
-
-@description('Name of the resource group for the public ip address')
-@allowed([
-  'Basic'
-  'Standard'
-])
-param publicIpSku string
-
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-03-01' = {
   name: virtualNetworkName
   location: location
@@ -83,10 +69,10 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2021-03-01' = {
   name: publicIpName
   location: location
   sku: {
-    name: publicIpSku
+    name: 'Standard'
   }
   properties: {
-    publicIPAllocationMethod: publicIpAllocationMethod
+    publicIPAllocationMethod: 'Static'
     dnsSettings: {
       domainNameLabel: toLower(publicIpDns)
     }


### PR DESCRIPTION
This is the same change we had to make for Azure in the terraform scripts in #20 to update the SKU of the Application Gateway to a newer one. This causes us to also use the standard SKU of the public IP address which in turn only supports static IP address allocation.