### PR TITLE
Adding availablity zone variable for PGSQL database

### DIFF
--- a/Azure/terraform/main.tf
+++ b/Azure/terraform/main.tf
@@ -50,15 +50,16 @@ module "storage" {
 }
 
 module "database" {
-  source        = "./modules/database/pgsql"
-# source        = "./modules/database/sql_server"
-  owner         = var.owner
-  rg_name       = azurerm_resource_group.fme_flow.name
-  location      = azurerm_resource_group.fme_flow.location
-  pgsql_snet_id = module.network.pgsql_snet_id
-  db_admin_user = var.db_admin_user
-  db_admin_pw   = var.db_admin_pw
-  dns_zone_id   = module.network.dns_zone_id
+  source            = "./modules/database/pgsql"
+# source            = "./modules/database/sql_server"
+  owner             = var.owner
+  rg_name           = azurerm_resource_group.fme_flow.name
+  location          = azurerm_resource_group.fme_flow.location
+  availability_zone = var.availability_zone
+  pgsql_snet_id     = module.network.pgsql_snet_id
+  db_admin_user     = var.db_admin_user
+  db_admin_pw       = var.db_admin_pw
+  dns_zone_id       = module.network.dns_zone_id
 }
 
 module "load_balancer" {

--- a/Azure/terraform/modules/database/pgsql/main.tf
+++ b/Azure/terraform/modules/database/pgsql/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_postgresql_flexible_server" "fme_flow" {
   create_mode                   = "Default"
   resource_group_name           = var.rg_name
   location                      = var.location
+  zone                          = var.availability_zone
   delegated_subnet_id           = var.pgsql_snet_id
   private_dns_zone_id           = var.dns_zone_id
   public_network_access_enabled = false

--- a/Azure/terraform/modules/database/pgsql/variables.tf
+++ b/Azure/terraform/modules/database/pgsql/variables.tf
@@ -34,3 +34,8 @@ variable "dns_zone_id" {
   type        = string
   description = "DNS Zone id"
 }
+
+variable "availability_zone" {
+  type = string
+  description = "Availability zone for the pgsql database"
+}

--- a/Azure/terraform/variables.tf
+++ b/Azure/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "owner" {
 
 variable "rg_name" {
   type        = string
-  default     = "QA"
+  default     = "terraform-rg"
   description = "Resource group name"
 }
 

--- a/Azure/terraform/variables.tf
+++ b/Azure/terraform/variables.tf
@@ -5,7 +5,7 @@ variable "owner" {
 
 variable "rg_name" {
   type        = string
-  default     = "terraform-rg"
+  default     = "QA"
   description = "Resource group name"
 }
 
@@ -132,4 +132,10 @@ variable "dns_zone_name" {
   type        = string
   default     = "fmeflow-pgsql-dns-zone"
   description = "Name of the private DNS Zone used by the pgsql database"
+}
+
+variable "availability_zone" {
+  type        = string
+  default     = "1" 
+  description = "Availability zone for the pgsql database"
 }


### PR DESCRIPTION
This change adds a new variable `availability_zone` to ensure the same zone is always used if a terraform deployment is updated. 