### PR TITLE
Adding FMEFlow health checks to load balancers and updating iam module

### DIFF
--- a/AWS/terraform/modules/iam/main.tf
+++ b/AWS/terraform/modules/iam/main.tf
@@ -17,9 +17,15 @@ resource "aws_iam_role" "fme_flow" {
       },
     ]
   })
+      tags = {
+    "Description" = "IAM role for ec2 instances to join a AD"
+    }
+}
   # This is policy makes sure the new ec2 instances can be join to the active directory. For more info check out this blog: https://aws.amazon.com/blogs/security/how-to-configure-your-ec2-instances-to-automatically-join-a-microsoft-active-directory-domain/
-  inline_policy {
+  resource "aws_iam_role_policy" "fme_flow_ec2_join" {
     name = "AmazonEC2RoleforSSM-ASGDomainJoin"
+    role = aws_iam_role.fme_flow.name
+
 
     policy = jsonencode({
       "Version" : "2012-10-17",
@@ -120,8 +126,9 @@ resource "aws_iam_role" "fme_flow" {
   }
 
   # This policy give the ec2 instances access to the scecrets for the RDS database and the FSx fileshare which is access via the AD admin account.
-  inline_policy {
+  resource "aws_iam_role_policy" "fme_flow_ec2_access" {
     name = "AmazonEC2RoleforSecretManager"
+    role = aws_iam_role.fme_flow.name
 
     policy = jsonencode({
       "Version" : "2012-10-17",
@@ -138,10 +145,6 @@ resource "aws_iam_role" "fme_flow" {
         }
       ]
     })
-
   }
 
-  tags = {
-    "Description" = "IAM role for ec2 instances to join a AD"
-  }
-}
+

--- a/AWS/terraform/modules/iam/main.tf
+++ b/AWS/terraform/modules/iam/main.tf
@@ -17,9 +17,9 @@ resource "aws_iam_role" "fme_flow" {
       },
     ]
   })
-      tags = {
+  tags = {
     "Description" = "IAM role for ec2 instances to join a AD"
-    }
+  }
 }
   # This is policy makes sure the new ec2 instances can be join to the active directory. For more info check out this blog: https://aws.amazon.com/blogs/security/how-to-configure-your-ec2-instances-to-automatically-join-a-microsoft-active-directory-domain/
   resource "aws_iam_role_policy" "fme_flow_ec2_join" {

--- a/AWS/terraform/modules/lb-services/alb/main.tf
+++ b/AWS/terraform/modules/lb-services/alb/main.tf
@@ -12,8 +12,10 @@ resource "aws_lb_target_group" "fme_flow_core" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
-  health_check {
-    path    = "/"
+    health_check {
+    path = "/fmeapiv4/healthcheck/liveness"
+    protocol = "HTTP"
+    port = "80"
     matcher = "200"
   }
 }
@@ -25,9 +27,10 @@ resource "aws_lb_target_group" "fme_flow_ws" {
   vpc_id   = var.vpc_id
 
   health_check {
-    path    = "/"
+    path = "/"
     matcher = "200-400"
   }
+
 }
 
 resource "aws_lb_listener" "fme_flow_core" {

--- a/AWS/terraform/modules/lb-services/alb/main.tf
+++ b/AWS/terraform/modules/lb-services/alb/main.tf
@@ -12,7 +12,7 @@ resource "aws_lb_target_group" "fme_flow_core" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
 
-    health_check {
+  health_check {
     path = "/fmeapiv4/healthcheck/liveness"
     protocol = "HTTP"
     port = "80"

--- a/AWS/terraform/modules/lb-services/nlb/main.tf
+++ b/AWS/terraform/modules/lb-services/nlb/main.tf
@@ -12,7 +12,7 @@ resource "aws_lb_target_group" "fme_flow_engine-registration" {
   vpc_id   = var.vpc_id
 
   health_check {
-    path = "/fmerest/v3/healthcheck"
+    path = "/fmeapiv4/healthcheck/liveness"
     port = "8080"
   }
 }

--- a/Azure/bicep/modules/lb-services/lb/lb.bicep
+++ b/Azure/bicep/modules/lb-services/lb/lb.bicep
@@ -12,6 +12,7 @@ param engineRegistrationLoadBalancerName string
 
 var engineRegistrationloadBalancerFrontEndName = 'engineRegistrationFrontend'
 var engineRegistrationloadBalancerBackEndName = 'engineRegistrationBackend'
+var fmeflow_health_check = 'loadBalancerHealthProbe'
 
 resource engineRegistrationLoadBalancer 'Microsoft.Network/loadBalancers@2023-09-01' = {
   name: engineRegistrationLoadBalancerName
@@ -51,6 +52,19 @@ resource engineRegistrationLoadBalancer 'Microsoft.Network/loadBalancers@2023-09
           backendPort: 7070
           enableFloatingIP: false
           idleTimeoutInMinutes: 30
+          probe: {
+            id: resourceId('Microsoft.Network/loadBalancers/probes', engineRegistrationLoadBalancerName, fmeflow_health_check)
+          }
+        }
+      }
+    ]
+    probes: [
+      {
+        name: fmeflow_health_check
+        properties: {
+          protocol: 'Http'
+          port: 8080
+          requestPath: '/fmeapiv4/healthcheck/liveness'
         }
       }
     ]

--- a/Azure/terraform/modules/lb-services/lb/main.tf
+++ b/Azure/terraform/modules/lb-services/lb/main.tf
@@ -12,8 +12,15 @@ resource "azurerm_lb" "fme_flow" {
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = var.be_snet_id
   }
-
   tags = local.default_tags
+}
+
+resource "azurerm_lb_probe" "fme_flow" {
+  loadbalancer_id = azurerm_lb.fme_flow.id
+  name            = "lb_healthcheck"
+  port            = 8080
+  protocol        = "Http"
+  request_path    = "/fmeapiv4/healthcheck/liveness"
 }
 
 resource "azurerm_lb_backend_address_pool" "fme_flow" {


### PR DESCRIPTION
This changing the following: 
- adds FMEFlow health checks to the engine registration load balancers
- adds FMEFlow heatlh check to AWS Terraform application load balancer
- updated IAM module for AWS Terraform due to deprecated argument