### PR TITLE
Update Azure deployment to enable cookie based affinity for the Websocket load balancing.

### DIFF
--- a/AWS/packer/fme_flow_aws.pkr.hcl
+++ b/AWS/packer/fme_flow_aws.pkr.hcl
@@ -29,7 +29,7 @@ locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 # build blocks. A build block runs provisioner and post-processors on a
 # source.
 source "amazon-ebs" "fme_core" {
-  ami_name              = "fme-core-2024-win-${local.timestamp}"
+  ami_name              = "fme-core-2025-win-${local.timestamp}"
   communicator          = "winrm"
   instance_type         = "m5.large"
   region                = "${var.region}"
@@ -57,7 +57,7 @@ source "amazon-ebs" "fme_core" {
 }
 
 source "amazon-ebs" "fme_engine" {
-  ami_name       = "fme-engine-2024-win-${local.timestamp}"
+  ami_name       = "fme-engine-2025-win-${local.timestamp}"
   communicator   = "winrm"
   instance_type  = "m5.large"
   region         = "${var.region}"
@@ -81,7 +81,7 @@ source "amazon-ebs" "fme_engine" {
 
 # a build block invokes sources and runs provisioning steps on them.
 build {
-  name    = "fme-core-2024"
+  name    = "fme-core-2025"
   sources = ["source.amazon-ebs.fme_core"]
   
   provisioner "file" {
@@ -102,7 +102,7 @@ build {
 }
 
 build {
-  name    = "fme-engine-2024"
+  name    = "fme-engine-2025"
   sources = ["source.amazon-ebs.fme_engine"]
   
   provisioner "file" {

--- a/Azure/bicep/modules/lb-services/agw/agw.bicep
+++ b/Azure/bicep/modules/lb-services/agw/agw.bicep
@@ -98,7 +98,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2021-08-01' =
         properties: {
           port: 7078
           protocol: 'Http'
-          cookieBasedAffinity: 'Disabled'
+          cookieBasedAffinity: 'Enabled'
           pickHostNameFromBackendAddress: true
           requestTimeout: 86400
           probe: {

--- a/Azure/terraform/modules/lb-services/agw/main.tf
+++ b/Azure/terraform/modules/lb-services/agw/main.tf
@@ -78,7 +78,7 @@ resource "azurerm_application_gateway" "fme_flow" {
     port                                = 7078
     protocol                            = "Http"
     request_timeout                     = 86400
-    cookie_based_affinity               = "Disabled"
+    cookie_based_affinity               = "Enabled"
     pick_host_name_from_backend_address = true
     probe_name                          = "websocketProbe"
 


### PR DESCRIPTION
Setting the cookie based affinity setting for websockets to true. Also updating the default names of images to 2025.