### PR TITLE
Fixing database error logging and improving Packer readme files

### DIFF
--- a/AWS/packer/README.md
+++ b/AWS/packer/README.md
@@ -14,21 +14,14 @@
 ### Create the AMIs
 1. Open a command line in the packer directory (directory with .pkr.hcl files)
 2. Run `packer init fme_flow_aws.pkr.hcl`
-3. Validate the script with set variables:
+3. Open the `variables.pkrvars.hcl` file and update the placeholder text for the `region`, FME `installer_url`, `source_ami` and `tags` variables with the values for your deployment.
+4. Validate the script with set variables:
 ```
-packer validate \
--var 'region=<REGION>' \
--var 'installer_url=<INSTALLER_URL>' \
--var 'tags={Owner="<OWNER",fme_build="<FME_BUILD>"}' \
-fme_flow_aws.pkr.hcl
+packer validate -var-file="variables.pkrvars.hcl" fme_flow_az.pkr.hcl
 ```
-4. Build the images:
+5. Build the images:
 ```
-packer build \
--var 'region=<REGION>' \
--var 'installer_url=<INSTALLER_URL>' \
--var 'tags={Owner="<OWNER",fme_build="<FME_BUILD>"}' \
-fme_flow_aws.pkr.hcl
+packer build -var-file="variables.pkrvars.hcl" fme_flow_az.pkr.hcl
 ```
 ### Modifying the AMIs
 To modify the AMI by installing additional 3rd party software or adding file packer provisioners, similar as used in this example for FME Flow, should be used. For more details please review this [documentation](https://www.packer.io/docs/provisioners)

--- a/AWS/packer/variables.pkrvars.hcl
+++ b/AWS/packer/variables.pkrvars.hcl
@@ -1,0 +1,8 @@
+region        = "<REGION>"
+installer_url = "<INSTALLER_URL>"
+source_ami    = "<AMI>"
+tags          = { 
+  "Owner" = "<OWNER>"
+  "Build" = "<FME_BUILD>"
+ }
+

--- a/Azure/packer/README.md
+++ b/Azure/packer/README.md
@@ -13,21 +13,14 @@
 ### Create the Windows Images
 1. Open a command line in the packer directory (directory with .pkr.hcl files)
 2. Run `packer init fme_flow_az.pkr.hcl`
+4. Open the `variables.pkrvars.hcl` file and update the placeholder text for the `resource_group`, FME `installer_url` and `tags` variables with the values for your deployment. 
 3. Validate the script with set variables:
 ```
-packer validate \
--var 'resource_group=<RESOURCE_GROUP_NAME>'
--var 'installer_url=<INSTALLER_URL>' \
--var 'tags={Owner="<OWNER>",fme_build="<FME_BUILD>"}' \
-fme_flow_az.pkr.hcl
+packer validate -var-file="variables.pkrvars.hcl" fme_flow_az.pkr.hcl
 ```
 4. Build the images:
 ```
-packer build \
--var 'resource_group=<RESOURCE_GROUP_NAME>'
--var 'installer_url=<INSTALLER_URL>' \
--var 'tags={Owner="<OWNER>",fme_build="<FME_BUILD>"}' \
-fme_flow_az.pkr.hcl
+packer build -var-file="variables.pkrvars.hcl" fme_flow_az.pkr.hcl
 ```
 ### Modifying the Windows Images
 To modify the Windows Images by installing additional 3rd party software or adding file packer provisioners, similar as used in this example for FME Flow, should be used. For more details please review this [documentation](https://www.packer.io/docs/provisioners).

--- a/Azure/packer/variables.pkrvars.hcl
+++ b/Azure/packer/variables.pkrvars.hcl
@@ -1,0 +1,7 @@
+resource_group = "<RESOURCE_GROUP>"
+installer_url  = "<INSTALLER_URL>"
+tags           = { 
+  "Owner" = "<OWNER>"
+  "Build" = "<FME_BUILD>"
+ }
+

--- a/config/powershell/config_fmeflow_confd.ps1
+++ b/config/powershell/config_fmeflow_confd.ps1
@@ -110,12 +110,22 @@ if($schemaExists -like "*t*") {
 }
 else {
     $env:PGPASSWORD = $databasePassword
+    $psqlPath = '"C:\Program Files\FMEFlow\Utilities\pgsql\bin\psql.exe"'
+    # Create User
+    $createUserCmd = "$psqlPath -d postgres -h $databasehostname -U $databaseUsername -p 5432 -f `"C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createUser.sql`" > `"C:\Program Files\FMEFlow\resources\logs\installation\CreateUser.log`" 2>&1"
+    cmd.exe /c $createUserCmd
 
-    & "C:\Program Files\FMEFlow\Utilities\pgsql\bin\psql.exe" -d postgres -h $databasehostname -U $databaseUsername -p 5432 -f "C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createUser.sql" >"C:\Program Files\FMEFlow\resources\logs\installation\CreateUser.log" 2>&1
-    & "C:\Program Files\FMEFlow\Utilities\pgsql\bin\psql.exe" -d postgres -h $databasehostname -U $databaseUsername -p 5432 -f "C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createDB.sql" >"C:\Program Files\FMEFlow\resources\logs\installation\CreateDatabase.log" 2>&1
+    # Create Database
+    $createDBCmd = "$psqlPath -d postgres -h $databasehostname -U $databaseUsername -p 5432 -f `"C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createDB.sql`" > `"C:\Program Files\FMEFlow\resources\logs\installation\CreateDatabase.log`" 2>&1"
+    cmd.exe /c $createDBCmd
 
+    # Switch password for fmeflow DB
     $env:PGPASSWORD = "fmeflow"
-    & "C:\Program Files\FMEFlow\Utilities\pgsql\bin\psql.exe" -d fmeflow -h $databasehostname -U $fmeDatabaseUsername -p 5432 -f "C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createSchema.sql" >"C:\Program Files\FMEFlow\resources\logs\installation\CreateSchema.log" 2>&1
+
+    # Create Schema
+    $createSchemaCmd = "$psqlPath -d fmeflow -h $databasehostname -U $fmeDatabaseUsername -p 5432 -f `"C:\Program Files\FMEFlow\Server\database\postgresql\postgresql_createSchema.sql`" > `"C:\Program Files\FMEFlow\resources\logs\installation\CreateSchema.log`" 2>&1"
+    cmd.exe /c $createSchemaCmd
+    
 }
 
 # create a script with the account name and password written into it to use at startup


### PR DESCRIPTION
Changes: 
- Errors will now be logged in `C:\Program Files\FMEFlow\resources\logs\installation\` if FMEFlow database scripts fail 
- Updated AWS/Azure packer readme files with instructions for building images with variables files
- Added variables files with placeholder values to packer directories 