### PR TITLE
Updating Azure templates to point at 2026.2 Marketplace images by default

### DIFF
--- a/Azure/bicep/modules/vmss/vmss_core/vmss_core.bicep
+++ b/Azure/bicep/modules/vmss/vmss_core/vmss_core.bicep
@@ -71,7 +71,7 @@ resource vmssNameCore_resource 'Microsoft.Compute/virtualMachineScaleSets@2021-0
   }
   plan: {
     publisher: 'safesoftwareinc'
-    name: 'fme-core-2026-1-windows-byol'
+    name: 'fme-core-2026-2-windows-byol'
     product: 'fme-core'
   }
   properties: {
@@ -90,7 +90,7 @@ resource vmssNameCore_resource 'Microsoft.Compute/virtualMachineScaleSets@2021-0
           // id: fmeCoreImage.id
           publisher: 'safesoftwareinc'
           offer: 'fme-core'
-          sku: 'fme-core-2026-1-windows-byol'
+          sku: 'fme-core-2026-2-windows-byol'
           version: 'latest'
         }
       }

--- a/Azure/bicep/modules/vmss/vmss_engine/vmss_engine.bicep
+++ b/Azure/bicep/modules/vmss/vmss_engine/vmss_engine.bicep
@@ -80,7 +80,7 @@ resource vmssNameEngine_resource 'Microsoft.Compute/virtualMachineScaleSets@2021
           // id: fmeEngineImage.id
           publisher: 'safesoftwareinc'
           offer: 'fme-engine'
-          sku: 'fme-engine-2026-1-windows-byol'
+          sku: 'fme-engine-2026-2-windows-byol'
           version: 'latest'
         }
       }

--- a/Azure/terraform/modules/vmss/vmss_core/main.tf
+++ b/Azure/terraform/modules/vmss/vmss_core/main.tf
@@ -36,12 +36,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "fme_flow_core" {
     
     publisher = "safesoftwareinc"
     offer     = "fme-core"
-    sku       = "fme-core-2026-1-windows-byol"
+    sku       = "fme-core-2026-2-windows-byol"
     version   = "latest"
   }
 
   plan {
-    name      = "fme-core-2026-1-windows-byol"
+    name      = "fme-core-2026-2-windows-byol"
     publisher = "safesoftwareinc"
     product   = "fme-core"
   }

--- a/Azure/terraform/modules/vmss/vmss_core_sql_server/main.tf
+++ b/Azure/terraform/modules/vmss/vmss_core_sql_server/main.tf
@@ -32,12 +32,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "fme_flow_core" {
   source_image_reference {
     publisher = "safesoftwareinc"
     offer     = "fme-core"
-    sku       = "fme-core-2026-1-windows-byol"
+    sku       = "fme-core-2026-2-windows-byol"
     version   = "latest"
   }
 
   plan {
-    name      = "fme-core-2026-1-windows-byol"
+    name      = "fme-core-2026-2-windows-byol"
     publisher = "safesoftwareinc"
     product   = "fme-core"
   }

--- a/Azure/terraform/modules/vmss/vmss_engine/main.tf
+++ b/Azure/terraform/modules/vmss/vmss_engine/main.tf
@@ -34,12 +34,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "fme_flow_engine" {
   source_image_reference {
     publisher = "safesoftwareinc"
     offer     = "fme-engine"
-    sku       = "fme-engine-2026-1-windows-byol"
+    sku       = "fme-engine-2026-2-windows-byol"
     version   = "latest"
   }
 
   plan {
-    name      = "fme-engine-2026-1-windows-byol"
+    name      = "fme-engine-2026-2-windows-byol"
     publisher = "safesoftwareinc"
     product   = "fme-engine"
   }

--- a/Azure/terraform/modules/vmss/vmss_engine_sql_server/main.tf
+++ b/Azure/terraform/modules/vmss/vmss_engine_sql_server/main.tf
@@ -31,12 +31,12 @@ resource "azurerm_windows_virtual_machine_scale_set" "fme_flow_engine" {
   source_image_reference {
     publisher = "safesoftwareinc"
     offer     = "fme-engine"
-    sku       = "fme-engine-2026-1-windows-byol"
+    sku       = "fme-engine-2026-2-windows-byol"
     version   = "latest"
   }
 
   plan {
-    name      = "fme-engine-2026-1-windows-byol"
+    name      = "fme-engine-2026-2-windows-byol"
     publisher = "safesoftwareinc"
     product   = "fme-engine"
   }


### PR DESCRIPTION
Ensures the most up to date FME images are used by default for Azure templates