### PR TITLE
Fix missing 2026.2 missing image reference for Azure Bicep

### DIFF
--- a/Azure/bicep/modules/vmss/vmss_engine/vmss_engine.bicep
+++ b/Azure/bicep/modules/vmss/vmss_engine/vmss_engine.bicep
@@ -61,7 +61,7 @@ resource vmssNameEngine_resource 'Microsoft.Compute/virtualMachineScaleSets@2021
   }
   plan: {
     publisher: 'safesoftwareinc'
-    name: 'fme-engine-2026-1-windows-byol'
+    name: 'fme-engine-2026-2-windows-byol'
     product: 'fme-engine'
   }
   properties: {


### PR DESCRIPTION
Reference to 2026.2 Engine marketplace image was missing in the engine bicep file 